### PR TITLE
changed padding of .hero-inner div in hero section

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -3342,7 +3342,7 @@ html {
     margin-left: auto;
     margin-right: auto;
     margin: auto;
-    padding: 7.5em;
+    padding: 10%;
     text-align: center; }
     .hero .hero-inner::after {
       clear: both;

--- a/css/partials/_hero.scss
+++ b/css/partials/_hero.scss
@@ -27,7 +27,7 @@
     @include outer-container;
     @include clearfix;
     margin: auto;
-    padding: 7.5em;
+    padding: 10%;
     text-align: center;
 
     .hero-copy {
@@ -52,6 +52,7 @@
           font-size: 1.1em;
           max-width: 40%;
         }
+
       }
     }
   }


### PR DESCRIPTION
Hi Sophia, I noticed the site had a weird look on mobile and i tried to fix it by changing the padding from 7.5em to 10%. ![image at 320px](https://cloud.githubusercontent.com/assets/13870224/15481936/c1a968de-2135-11e6-8cf9-da0582bc7769.png) at 320px width compared to ![corrected padding at 320px](https://cloud.githubusercontent.com/assets/13870224/15482079/806063f4-2136-11e6-88c1-d64b3603950b.png) at the same width with the padding corrected. 

